### PR TITLE
Add trim_prerelease_info function

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in mb-fastlane_extensions.gemspec
 gemspec
 
-gem "rake", "~> 12.0"
-gem "rspec", "~> 3.0"
+gem 'rake', '~> 12.0'
+gem 'rspec', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,55 @@
+PATH
+  remote: .
+  specs:
+    mb-fastlane_extensions (0.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.1)
+    diff-lcs (1.4.4)
+    parallel (1.19.2)
+    parser (2.7.2.0)
+      ast (~> 2.4.1)
+    rainbow (3.0.0)
+    rake (12.3.2)
+    regexp_parser (1.8.2)
+    rexml (3.2.4)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.3)
+    rubocop (1.0.0)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.5)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8)
+      rexml
+      rubocop-ast (>= 0.6.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (1.1.0)
+      parser (>= 2.7.1.5)
+    ruby-progressbar (1.10.1)
+    unicode-display_width (1.7.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  mb-fastlane_extensions!
+  rake (~> 12.0)
+  rspec (~> 3.0)
+  rubocop
+
+BUNDLED WITH
+   2.1.4

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-require "bundler/setup"
-require "mb/fastlane_extensions"
+require 'bundler/setup'
+require 'mb/fastlane_extensions'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +11,5 @@ require "mb/fastlane_extensions"
 # require "pry"
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start(__FILE__)

--- a/lib/mb/fastlane_extensions.rb
+++ b/lib/mb/fastlane_extensions.rb
@@ -6,6 +6,16 @@ module Mb
   # Extensions to Fastlane as needed by MB.
   module FastlaneExtensions
     class Error < StandardError; end
-    # Your code goes here...
+
+    def self.trim_prerelease_info(semantic_version)
+      # rubocop:disable Layout/LineLength
+      semver_regexp = /(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/
+      # rubocop:enable Layout/LineLength
+
+      matched_data = semver_regexp.match(semantic_version)
+      raise Error if matched_data.nil?
+
+      [matched_data[1], matched_data[2], matched_data[3]].join('.')
+    end
   end
 end

--- a/lib/mb/fastlane_extensions.rb
+++ b/lib/mb/fastlane_extensions.rb
@@ -1,6 +1,9 @@
-require "mb/fastlane_extensions/version"
+# frozen_string_literal: true
+
+require 'mb/fastlane_extensions/version'
 
 module Mb
+  # Extensions to Fastlane as needed by MB.
   module FastlaneExtensions
     class Error < StandardError; end
     # Your code goes here...

--- a/lib/mb/fastlane_extensions/version.rb
+++ b/lib/mb/fastlane_extensions/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Mb
   module FastlaneExtensions
-    VERSION = "0.1.0"
+    VERSION = '0.1.0'
   end
 end

--- a/mb-fastlane_extensions.gemspec
+++ b/mb-fastlane_extensions.gemspec
@@ -1,29 +1,33 @@
+# frozen_string_literal: true
+
 require_relative 'lib/mb/fastlane_extensions/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "mb-fastlane_extensions"
+  spec.name          = 'mb-fastlane_extensions'
   spec.version       = Mb::FastlaneExtensions::VERSION
-  spec.authors       = ["Mickaël Floc’hlay"]
-  spec.email         = ["mickael.flochlay@memo.bank"]
+  spec.authors       = ['Mickaël Floc’hlay']
+  spec.email         = ['mickael.flochlay@memo.bank']
 
-  spec.summary       = %q{TODO: Write a short summary, because RubyGems requires one.}
-  spec.description   = %q{TODO: Write a longer description or delete this line.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
-  spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.summary       = 'Extensions for Fastlane.'
+  spec.description   = 'Extensions for Fastlane.'
+  spec.homepage      = 'https://github.com/dirtyhenry/mb-fastlane_extensions'
+  spec.license       = 'MIT'
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
 
-  spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+  # spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
 
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
-  spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = 'https://github.com/dirtyhenry/mb-fastlane_extensions'
+  spec.metadata['changelog_uri'] = 'https://github.com/dirtyhenry/mb-fastlane_extensions/blob/main/CHANGELOG.md'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
+
+  spec.add_development_dependency 'rubocop'
 end

--- a/spec/mb/fastlane_extensions_spec.rb
+++ b/spec/mb/fastlane_extensions_spec.rb
@@ -5,7 +5,11 @@ RSpec.describe Mb::FastlaneExtensions do
     expect(Mb::FastlaneExtensions::VERSION).not_to be nil
   end
 
-  it 'does something useful' do
-    expect(false).to eq(true)
+  it 'can trim semantic version tags' do
+    expect(Mb::FastlaneExtensions.trim_prerelease_info('1.0.0')).to eq('1.0.0')
+    expect(Mb::FastlaneExtensions.trim_prerelease_info('1.0.0-alpha')).to eq('1.0.0')
+    expect(Mb::FastlaneExtensions.trim_prerelease_info('3.2.1-alpha.123')).to eq('3.2.1')
+    expect { Mb::FastlaneExtensions.trim_prerelease_info('not a version') }
+      .to raise_error(Mb::FastlaneExtensions::Error)
   end
 end

--- a/spec/mb/fastlane_extensions_spec.rb
+++ b/spec/mb/fastlane_extensions_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 RSpec.describe Mb::FastlaneExtensions do
-  it "has a version number" do
+  it 'has a version number' do
     expect(Mb::FastlaneExtensions::VERSION).not_to be nil
   end
 
-  it "does something useful" do
+  it 'does something useful' do
     expect(false).to eq(true)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,11 @@
-require "bundler/setup"
-require "mb/fastlane_extensions"
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'mb/fastlane_extensions'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = '.rspec_status'
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!


### PR DESCRIPTION
The point of this function is to trim prerelease version numbers to their canonical equivalent, ie: 

* `1.0.0` → `1.0.0`
* `1.0.0-alpha` → `1.0.0`
* `3.2.1-alpha.123` → `3.2.1`
 